### PR TITLE
release 2020-05-09

### DIFF
--- a/.autoexec.sh
+++ b/.autoexec.sh
@@ -1,7 +1,7 @@
 ######################################################## SSH KEYS ######################################################
 eval $(ssh-agent -s)
 
-for key in $(ls /root/.ssh/ | grep -v -E  ".pub|known_hosts|config|.iml" )
+for key in $(ls -p /root/.ssh/ | grep -v -E  ".pub|known_hosts|config|.iml|/" )
 do
 	ssh-add "/root/.ssh/$key"
 done
@@ -10,8 +10,10 @@ done
 
 #GENERIC
 alias getpubip='curl https://ipinfo.io/ip'
+alias unproxy='unset HTTP_PROXY && unset HTTPS_PROXY && unset http_proxy && unset https_proxy'
 
 #KUBECTL
+alias k='kubectl'
 alias ksn='kubectl config set-context $(kubectl config current-context) --namespace '
 alias kgc='kubectl config get-contexts'
 alias ksc='kubectl config use-context '
@@ -21,6 +23,10 @@ update-ca-certificates
 
 ######################################################## UNSET CONTAINER ENV ###########################################
 unset TILLER_NAMESPACE
+
+######################################################## SET USER-SPECIFIC ENV #########################################
+
+export MAKEFILE_REPO=/root/project/dev/github/makefiles
 
 ######################################################## DONE ##########################################################
 echo "$( cd "$(dirname "$0")" ; pwd -P )/.autoexec.sh loaded successfully!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ ARG UBUNTU_VERSION=18.04
 ARG OC_CLI_SOURCE="https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz"
 
 ARG DOCKER_VERSION="19.03.8"
-ARG KUBECTL_VERSION="1.18.0"
-ARG HELM_VERSION="2.16.5"
-ARG HELM3_VERSION="3.1.2"
+ARG KUBECTL_VERSION="1.18.2"
+ARG HELM_VERSION="2.16.7"
+ARG HELM3_VERSION="3.2.1"
 ARG TERRAFORM_VERSION="0.12.24"
-ARG AWS_CLI_VERSION="1.18.36"
-ARG AZ_CLI_VERSION="2.3.1-1~bionic"
-ARG KOPS_VERSION="1.16.0"
-ARG ANSIBLE_VERSION="2.9.6"
-ARG JINJA_VERSION="2.11.1"
+ARG AWS_CLI_VERSION="1.18.56"
+ARG AZ_CLI_VERSION="2.5.1-1~bionic"
+ARG KOPS_VERSION="1.16.2"
+ARG ANSIBLE_VERSION="2.9.7"
+ARG JINJA_VERSION="2.11.2"
 ARG OPENSSH_VERSION="8.2p1"
 
 ARG ZSH_VERSION="5.4.2-3ubuntu3.1"
@@ -73,7 +73,7 @@ RUN curl -Lo kops https://github.com/kubernetes/kops/releases/download/v$KOPS_VE
 
 ######################################################### IMAGE ########################################################
 
-FROM ubuntu:18.04
+FROM ubuntu:$UBUNTU_VERSION
 MAINTAINER Kevin Sandermann <kevin.sandermann@gmail.com>
 LABEL maintainer="kevin.sandermann@gmail.com"
 
@@ -124,10 +124,12 @@ RUN apt-get update && \
     software-properties-common \
     sudo \
     telnet \
+    traceroute \
     unzip \
     uuid-runtime \
     vim \
     wget \
+    zip \
     zlib1g-dev &&\
     apt-get clean -y && \
     apt-get autoclean -y && \
@@ -227,4 +229,4 @@ COPY .bashrc /root/.bashrc
 COPY .zshrc /root/.zshrc
 
 WORKDIR /root/project
-CMD ["/bin/zsh"]
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ Feel free to use/share/contribute.
 
 # default shell & custom startup-script
 The default shell is sh.
-However, the CMD step inside the Dockerfile as well as the default command inside run.sh points to /bin/zsh.
+However, the CMD step inside the Dockerfile points to /bin/bash.
 By default, the file .autoexec.sh will be mounted into the container and sourced inside both bash and zsh.
+
+# run.sh
+The behaviour of run.sh is as follows:
+1. check if there is already a running toolbox.
+1. if so, attach to the container and start a new shell (/bin/bash) inside it.
+1. if no, start a new interactive container and start a new shell (/bin/zsh) inside it.
 
 # custom ca certificates`
 All CAs placed inside ```~/ca-certificates``` on the host system will be mounted into the container and trusted on startup.
@@ -24,10 +30,12 @@ Other versions of a date can contain version combinations of the toolchain and w
 below.
 
 ## version history
-project -> 2020-04-04_02
+project -> 2020-05-09_02
 
 | RELEASE       | UBUNTU | DOCKER   | KUBECTL  | OC CLI | HELM   | HELM3   | TERRAFORM | AWS CLI  | AZ CLI | KOPS   | ANSIBLE | JINJA2 | OPENSSH |
 |---------------|--------|----------|----------|--------|--------|---------|-----------|----------|--------|--------|---------|--------|---------|
+| 2020-05-09_01 | 18.04  | 19.03.8  | 1.18.2   | 3.11   | 2.16.7 | 3.2.1   | 0.12.24   | 1.18.56  | 2.5.1  | 1.16.2 | 2.9.7   | 2.11.2 | 8.2p1   |
+| 2020-05-09_02 | 18.04  | 19.03.8  | 1.15.12  | 3.11   | 2.16.1 | 3.2.1   | 0.12.24   | 1.18.56  | 2.5.1  | 1.16.2 | 2.9.7   | 2.11.2 | 8.2p1   |
 | 2020-04-04_01 | 18.04  | 19.03.8  | 1.18.0   | 3.11   | 2.16.5 | 3.1.2   | 0.12.24   | 1.18.36  | 2.3.1  | 1.16.0 | 2.9.6   | 2.11.1 | 8.2p1   |
 | 2020-04-04_02 | 18.04  | 19.03.8  | 1.15.11  | 3.11   | 2.16.1 | 3.1.2   | 0.12.24   | 1.18.36  | 2.3.1  | 1.16.0 | 2.9.6   | 2.11.1 | 8.2p1   |
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2020-04-04_01"
+IMAGE_TAG="2020-05-09_01"
 UPSTREAM_TAG="latest"
 
 docker build \

--- a/run.sh
+++ b/run.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+IMAGE_TAG="latest"
 TOOLBOX_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
-IMAGE_TAG="latest"
-
-docker run -ti --rm \
+#functions
+function startNewToolbox {
+  docker run -ti --rm \
     --name toolbox \
     -v ~/.kube:/root/.kube \
     -v ~/.helm:/root/.helm \
@@ -21,3 +22,15 @@ docker run -ti --rm \
     --env-file <(env | grep proxy) \
     ksandermann/cloud-toolbox:$IMAGE_TAG \
     /bin/zsh
+}
+
+function attachToToolbox {
+  docker exec -it toolbox /bin/bash
+}
+
+if [[ "$(docker ps -a | grep toolbox)" ]]
+then
+    attachToToolbox
+else
+    startNewToolbox
+fi


### PR DESCRIPTION
# Changelog

* bumped kubectl to 1.18.2
* bumped helm to 2.16.7
* bumped helm3 to 3.2.1
* bumped aws-cli to 1.18.56
* bumped azure-cli to 2.5.1
* bumped kops to 1.16.2
* bumped ansible to 2.9.7
 * bumped jinja2 to 2.11.2

* changed default behaviour of run.sh. Fore more information, see README.md
* added traceroute and zip
* changed CMD to /bin/bash
* added aliases unproxy and k
* fixed ssh-add trying to add sub-directories of .ssh
