### PR TITLE
released 2020-12-07

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,18 @@ ARG HELM_VERSION="2.17.0"
 ARG HELM3_VERSION="3.4.1"
 ARG TERRAFORM_VERSION="0.12.29"
 ARG TERRAFORM13_VERSION="0.13.5"
-ARG AWS_CLI_VERSION="1.18.178"
-ARG AZ_CLI_VERSION="2.14.2-1~bionic"
-ARG GCLOUD_VERSION="318.0.0-0"
+ARG TERRAFORM14_VERSION="0.14.0"
+ARG AWS_CLI_VERSION="1.18.190"
+ARG AZ_CLI_VERSION="2.15.1-1~bionic"
+ARG GCLOUD_VERSION="319.0.0-0"
 ARG KOPS_VERSION="1.18.2"
-ARG ANSIBLE_VERSION="2.10.3"
+ARG ANSIBLE_VERSION="2.10.4"
 ARG JINJA_VERSION="2.11.2"
 ARG OPENSSH_VERSION="8.4p1"
 ARG CRICTL_VERSION="1.19.0"
 
 ARG ZSH_VERSION="5.4.2-3ubuntu3.1"
-ARG MULTISTAGE_BUILDER_VERSION="2020-06-19"
+ARG MULTISTAGE_BUILDER_VERSION="2020-12-07"
 
 ######################################################### BUILDER ######################################################
 FROM ksandermann/multistage-builder:$MULTISTAGE_BUILDER_VERSION as builder
@@ -31,6 +32,7 @@ ARG HELM_VERSION
 ARG HELM3_VERSION
 ARG TERRAFORM_VERSION
 ARG TERRAFORM13_VERSION
+ARG TERRAFORM14_VERSION
 ARG DOCKER_VERSION
 ARG KUBECTL_VERSION
 ARG KOPS_VERSION
@@ -48,14 +50,18 @@ RUN mkdir helm2 && curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM_VERSION-
 #download helm3-cli
 RUN mkdir helm3 && curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM3_VERSION-linux-amd64.tar.gz" | tar xz -C ./helm3
 
-#download terraform
+#download terraform 0.12
 WORKDIR /root/download
 RUN wget https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform\_$TERRAFORM_VERSION\_linux_amd64.zip && \
     unzip ./terraform\_$TERRAFORM_VERSION\_linux_amd64.zip -d terraform_cli
 
-#download terraform
+#download terraform 0.13
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM13_VERSION}/terraform\_${TERRAFORM13_VERSION}\_linux_amd64.zip && \
     unzip ./terraform\_${TERRAFORM13_VERSION}\_linux_amd64.zip -d terraform13_cli
+
+#download terraform 0.14
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM14_VERSION}/terraform\_${TERRAFORM14_VERSION}\_linux_amd64.zip && \
+    unzip ./terraform\_${TERRAFORM14_VERSION}\_linux_amd64.zip -d terraform14_cli
 
 #download docker
 #credits to https://github.com/docker-library/docker/blob/463595652d2367887b1ffe95ec30caa00179be72/18.09/Dockerfile
@@ -228,6 +234,7 @@ COPY --from=builder "/root/download/helm3/linux-amd64/helm" "/usr/local/bin/helm
 COPY --from=builder "/root/download/oc_cli/oc" "/usr/local/bin/oc"
 COPY --from=builder "/root/download/terraform_cli/terraform" "/usr/local/bin/terraform"
 COPY --from=builder "/root/download/terraform13_cli/terraform" "/usr/local/bin/terraform13"
+COPY --from=builder "/root/download/terraform14_cli/terraform" "/usr/local/bin/terraform14"
 COPY --from=builder "/root/download/docker/bin/*" "/usr/local/bin/"
 COPY --from=builder "/root/download/kubectl" "/usr/local/bin/kubectl"
 COPY --from=builder "/root/download/crictl/crictl" "/usr/local/bin/crictl"
@@ -244,6 +251,7 @@ RUN chmod -R +x /usr/local/bin && \
     oc version --client && \
     terraform version && \
     terraform13 version && \
+    terraform14 version && \
     docker --version && \
     kops version && \
     yq --version && \

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The behaviour of run.sh is as follows:
 # custom ca certificates`
 All CAs placed inside ```~/ca-certificates``` on the host system will be mounted into the container and trusted on startup.
 
-# helm 3 and terraform 0.13
+# helm 3 and terraform 0.13/0.14
 While a lot of projects are upgrading to helm 3, helm 2 will probably still be around for some time.
 As helm 3 does not provide backward-compatibility, both versions are installed in parallel in cloud-toolbox.
 Helm 2 can be used as before to provide backward-compatibility, helm 3 can be used via binary `helm3`.
-The same pattern applies to terraform 0.12 and 0.13 - 0.12 can be used via binary `terraform`, while 0.13 is available via binary `terraform13`.
+The same pattern applies to terraform 0.12, 0.13 and 0.14 - 0.12 can be used via binary `terraform`, while 0.13 is available via binary `terraform13` and 0.14 via binary `terraform14`.
 
 # versioning 
 Release tags will be build following pattern YYYY-MM-dd-version.
@@ -31,13 +31,15 @@ Other versions of a date can contain version combinations of the toolchain and w
 below.
 
 ## version history
-latest -> 2020-11-14_01
+latest -> 2020-12-07_01
 
-project -> 2020-11-14_02
+project -> 2020-12-07_02
 
 
-| RELEASE       | UBUNTU | DOCKER   | KUBECTL  | OC CLI | HELM    | HELM3   | TERRAFORM | TERRAFORM13   | AWS CLI  | AZ CLI | GCLOUD SDK | KOPS   | ANSIBLE | JINJA2 | OPENSSH | CRICTL |
+| RELEASE       | UBUNTU | DOCKER   | KUBECTL  | OC CLI | HELM    | HELM3   | TERRAFORM | TERRAFORM14   | AWS CLI  | AZ CLI | GCLOUD SDK | KOPS   | ANSIBLE | JINJA2 | OPENSSH | CRICTL |
 |---------------|--------|----------|----------|--------|---------|---------|-----------|---------------|----------|--------|------------|--------|---------|--------|---------|--------|
+| 2020-12-07_01 | 18.04  | 19.03.13 | 1.19.4   | 4.6    | 2.17.0  | 3.4.1   | 0.12.29   | 0.14.0        | 1.18.190 | 2.15.1 | 319.0.0    | 1.18.2 | 2.10.4  | 2.11.2 | 8.4p1   | 1.19.0 |
+| 2020-12-07_02 | 18.04  | 19.03.13 | 1.18.12  | 4.6    | 2.17.0  | 3.4.1   | 0.12.29   | 0.14.0        | 1.18.190 | 2.15.1 | 319.0.0    | 1.18.2 | 2.10.4  | 2.11.2 | 8.4p1   | 1.19.0 |
 | 2020-11-14_01 | 18.04  | 19.03.13 | 1.19.4   | 4.6    | 2.17.0  | 3.4.1   | 0.12.29   | 0.13.5        | 1.18.178 | 2.14.2 | 318.0.0    | 1.18.2 | 2.10.3  | 2.11.2 | 8.4p1   | 1.19.0 |
 | 2020-11-14_02 | 18.04  | 19.03.13 | 1.18.12  | 4.6    | 2.17.0  | 3.4.1   | 0.12.29   | 0.13.5        | 1.18.178 | 2.14.2 | 318.0.0    | 1.18.2 | 2.10.3  | 2.11.2 | 8.4p1   | 1.19.0 |
 | 2020-10-27_01 | 18.04  | 19.03.13 | 1.19.3   | 4.6    | 2.17.0  | 3.4.0   | 0.12.29   | 0.13.5        | 1.18.165 | 2.14.0 | 316.0.0    | 1.18.2 | 2.10.1  | 2.11.2 | 8.4p1   | 1.19.0 |

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2020-11-14_01"
+IMAGE_TAG="2020-12-07_01"
 UPSTREAM_TAG="latest"
 
 docker build \


### PR DESCRIPTION
# changelog

* bumped aws-cli to 1.18.190
* bumped azure-cli to 2.15.1 
* bumped gcloud-sdk to 319.0.0 
* bumped ansible to.2.10.4 
* bumped multistage-builder to 2012-12-07 
* added terraform 0.14
