### PR TITLE
release 2021-04-17_01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,22 +3,21 @@
 ARG UBUNTU_VERSION=20.04
 
 ARG DOCKER_VERSION="20.10.5"
-ARG KUBECTL_VERSION="1.20.5"
+ARG KUBECTL_VERSION="1.20.6"
 ARG OC_CLI_VERSION="4.6"
 ARG HELM2_VERSION="2.17.0"
-ARG HELM_VERSION="3.5.3"
-ARG TERRAFORM12_VERSION="0.12.30"
-ARG TERRAFORM13_VERSION="0.13.6"
-ARG TERRAFORM_VERSION="0.14.9"
-ARG AWS_CLI_VERSION="1.19.44"
-ARG AZ_CLI_VERSION="2.21.0-1~focal"
-ARG GCLOUD_VERSION="334.0.0-0"
+ARG HELM_VERSION="3.5.4"
+ARG TERRAFORM14_VERSION="0.14.10"
+ARG TERRAFORM_VERSION="0.15.0"
+ARG AWS_CLI_VERSION="1.19.53"
+ARG AZ_CLI_VERSION="2.22.0-1~focal"
+ARG GCLOUD_VERSION="336.0.0-0"
 ARG ANSIBLE_VERSION="3.2.0"
 ARG JINJA_VERSION="2.11.3"
 ARG OPENSSH_VERSION="8.5p1"
-ARG CRICTL_VERSION="1.20.0"
+ARG CRICTL_VERSION="1.21.0"
 ARG VAULT_VERSION="1.7.0"
-ARG VELERO_VERSION="1.5.4"
+ARG VELERO_VERSION="1.6.0"
 ARG STERN_VERSION="1.14.0"
 ARG SENTINEL_VERSION="0.18.0"
 
@@ -33,8 +32,7 @@ LABEL maintainer="kevin.sandermann@gmail.com"
 ARG OC_CLI_VERSION
 ARG HELM2_VERSION
 ARG HELM_VERSION
-ARG TERRAFORM12_VERSION
-ARG TERRAFORM13_VERSION
+ARG TERRAFORM14_VERSION
 ARG TERRAFORM_VERSION
 ARG DOCKER_VERSION
 ARG KUBECTL_VERSION
@@ -57,16 +55,11 @@ RUN mkdir helm2 && curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM2_VERSION
 #download helm3-cli
 RUN mkdir helm && curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz" | tar xz -C ./helm
 
-#download terraform 0.12
-WORKDIR /root/download
-RUN wget https://releases.hashicorp.com/terraform/$TERRAFORM12_VERSION/terraform\_$TERRAFORM12_VERSION\_linux_amd64.zip && \
-    unzip ./terraform\_$TERRAFORM12_VERSION\_linux_amd64.zip -d terraform12_cli
-
-#download terraform 0.13
-RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM13_VERSION}/terraform\_${TERRAFORM13_VERSION}\_linux_amd64.zip && \
-    unzip ./terraform\_${TERRAFORM13_VERSION}\_linux_amd64.zip -d terraform13_cli
-
 #download terraform 0.14
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM14_VERSION}/terraform\_${TERRAFORM14_VERSION}\_linux_amd64.zip && \
+    unzip ./terraform\_${TERRAFORM14_VERSION}\_linux_amd64.zip -d terraform14_cli
+
+#download terraform
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform\_${TERRAFORM_VERSION}\_linux_amd64.zip && \
     unzip ./terraform\_${TERRAFORM_VERSION}\_linux_amd64.zip -d terraform_cli
 
@@ -269,8 +262,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 COPY --from=builder "/root/download/helm2/linux-amd64/helm" "/usr/local/bin/helm2"
 COPY --from=builder "/root/download/helm/linux-amd64/helm" "/usr/local/bin/helm"
 COPY --from=builder "/root/download/oc_cli/oc" "/usr/local/bin/oc"
-COPY --from=builder "/root/download/terraform12_cli/terraform" "/usr/local/bin/terraform12"
-COPY --from=builder "/root/download/terraform13_cli/terraform" "/usr/local/bin/terraform13"
+COPY --from=builder "/root/download/terraform14_cli/terraform" "/usr/local/bin/terraform14"
 COPY --from=builder "/root/download/terraform_cli/terraform" "/usr/local/bin/terraform"
 COPY --from=builder "/root/download/docker/bin/*" "/usr/local/bin/"
 COPY --from=builder "/root/download/kubectl" "/usr/local/bin/kubectl"
@@ -292,8 +284,7 @@ RUN chmod -R +x /usr/local/bin && \
     kubectl version --client=true && \
     crictl --version && \
     oc version --client && \
-    terraform12 version && \
-    terraform13 version && \
+    terraform14 version && \
     terraform version && \
     docker --version && \
     yq --version && \

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The behaviour of run.sh is as follows:
 # custom ca certificates`
 All CAs placed inside ```~/ca-certificates``` on the host system will be mounted into the container and trusted on startup.
 
-# helm 3 and terraform 0.13/0.14
+# helm 3 and terraform 0.14/0.15
 While a lot of projects are upgrading to helm 3, helm 2 will probably still be around for some time.
-As helm 3 does not provide backward-compatibility, both versions are installed in parallel in cloud-toolbox.
-Helm 2 can be used as before via binary `helm2`, while helm3 can be natively used using `helm`.
-The same pattern applies to terraform 0.12 and 0.14 - 0.12 can be used via binary `terraform12`, while 0.14 is available via binary `terraform`.
+As helm 3 does not provide backwards-compatibility, both versions are installed in parallel in cloud-toolbox.
+Helm 2 can be used via binary `helm2`, while helm3 can be used natively using `helm`.
+The same pattern applies to terraform 0.14 and 0.15 - 0.14 can be used via binary `terraform14`, while 0.15 is available via binary `terraform`.
 
 # versioning
 Release tags will be build following pattern YYYY-MM-dd-version.
@@ -31,12 +31,13 @@ Other versions of a date can contain version combinations of the toolchain and w
 below.
 
 ## version history
-latest -> 2021-04-04_01
-project -> 2021-04-04_01
+latest -> 2021-04-17_01
+project -> 2021-04-17_01
 
 
 | RELEASE       | UBUNTU | DOCKER   | KUBECTL  | OC CLI | HELM2    | HELM   | TERRAFORM | AWS CLI  | AZ CLI | GCLOUD SDK | ANSIBLE | JINJA2 | OPENSSH | CRICTL | VAULT | VELERO | SENTINEL |
 |---------------|--------|----------|----------|--------|----------|--------|-----------|----------|--------|------------|---------|--------|---------|--------|-------|--------|----------|
+| 2021-04-17_01 | 20.04  | 20.10.5  | 1.20.6   | 4.6    | 2.17.0   | 3.5.4  | 0.15.0    | 1.19.53  | 2.22.0 | 336.0.0    | 3.2.0   | 2.11.3 | 8.5p1   | 1.21.0 | 1.7.0 | 1.6.0  |  0.18.0  |
 | 2021-04-04_01 | 20.04  | 20.10.5  | 1.20.5   | 4.6    | 2.17.0   | 3.5.3  | 0.14.9    | 1.19.44  | 2.21.0 | 334.0.0    | 3.2.0   | 2.11.3 | 8.5p1   | 1.20.0 | 1.7.0 | 1.5.4  |  0.18.0  |
 | 2021-03-18_01 | 20.04  | 20.10.5  | 1.20.4   | 4.6    | 2.17.0   | 3.5.3  | 0.14.7    | 1.19.30  | 2.20.0 | 332.0.0    | 3.1.0   | 2.11.3 | 8.5p1   | 1.20.0 | 1.6.3 | 1.5.3  |  0.17.4  |
 | 2021-03-09_01 | 20.04  | 20.10.5  | 1.20.4   | 4.6    | 2.17.0   | 3.5.2  | 0.14.7    | 1.19.23  | 2.20.0 | 330.0.0    | 3.0.0   | 2.11.3 | 8.5p1   | 1.20.0 | 1.6.3 | 1.5.3  |    N/A   |

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2021-04-04_01"
+IMAGE_TAG="2021-04-17_01"
 UPSTREAM_TAG="latest"
 UPSTREAM_TAG2="project"
 


### PR DESCRIPTION
# changelog

* bumped kubectl to 1.20.6
* bumped helm to 3.5.4
* bumped terraform to 0.15.0
* moved terraform 0.14.10 to terraform14
* removed terraform12
* removed terraform13
* bumped aws cli to 1.19.53
* bumped azure cli to 2.22.0
* bumped google-cloud-sdk to 336.0.0
* bumped crictl to 1.21.0
* bumped velero to 1.6.0