### PR TITLE
release 2022-04-26_01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,36 +3,36 @@
 ARG UBUNTU_VERSION=20.04
 
 #https://docs.docker.com/engine/release-notes/
-ARG DOCKER_VERSION="20.10.13"
+ARG DOCKER_VERSION="20.10.14"
 #https://github.com/kubernetes/kubernetes/releases
-ARG KUBECTL_VERSION="1.23.5"
+ARG KUBECTL_VERSION="1.23.6"
 #https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
-ARG OC_CLI_VERSION="4.10.3"
+ARG OC_CLI_VERSION="4.10.9"
 #https://github.com/helm/helm/releases
-ARG HELM_VERSION="3.8.1"
+ARG HELM_VERSION="3.8.2"
 ARG TERRAFORM14_VERSION="0.14.11"
 #https://github.com/hashicorp/terraform/releases
-ARG TERRAFORM_VERSION="1.1.7"
+ARG TERRAFORM_VERSION="1.1.9"
 #https://pypi.org/project/awscli/
-ARG AWS_CLI_VERSION="1.22.76"
+ARG AWS_CLI_VERSION="1.23.0"
 #apt-get update && apt-cache madison azure-cli | head -n 1
-ARG AZ_CLI_VERSION="2.34.1-1~focal"
+ARG AZ_CLI_VERSION="2.36.0-1~focal"
 #apt-get update && apt-cache madison google-cloud-sdk | head -n 1
-ARG GCLOUD_VERSION="377.0.0-0"
+ARG GCLOUD_VERSION="382.0.0-0"
 #https://pypi.org/project/ansible/
-ARG ANSIBLE_VERSION="5.5.0"
+ARG ANSIBLE_VERSION="5.6.0"
 #https://pypi.org/project/Jinja2/
-ARG JINJA_VERSION="3.0.3"
+ARG JINJA_VERSION="3.1.1"
 #https://mirror.exonetric.net/pub/OpenBSD/OpenSSH/portable/
-ARG OPENSSH_VERSION="8.9p1"
+ARG OPENSSH_VERSION="9.0p1"
 #https://github.com/kubernetes-sigs/cri-tools/releases
 ARG CRICTL_VERSION="1.23.0"
 #https://github.com/hashicorp/vault/releases
-ARG VAULT_VERSION="1.9.4"
+ARG VAULT_VERSION="1.10.1"
 #https://github.com/vmware-tanzu/velero/releases
 ARG VELERO_VERSION="1.8.1"
 #https://docs.hashicorp.com/sentinel/changelog
-ARG SENTINEL_VERSION="0.18.7"
+ARG SENTINEL_VERSION="0.18.9"
 #https://github.com/stern/stern/releases
 ARG STERN_VERSION="1.21.0"
 #apt-get update && apt-cache madison zsh | head -n 1

--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ Other versions of a date can contain version combinations of the toolchain and w
 below.
 
 ## version history
-latest -> 2022-03-17_01
+latest -> 2022-04-26_01
 
-project -> 2022-03-17_01
+project -> 2022-04-26_01
 
 
-| RELEASE       | UBUNTU | DOCKER   | KUBECTL  | OC CLI | HELM   | TERRAFORM | AWS CLI  | AZ CLI | GCLOUD SDK | ANSIBLE | JINJA2 | OPENSSH | CRICTL | VAULT | VELERO | SENTINEL |
-|---------------|--------|----------|----------|--------|--------|-----------|----------|--------|------------|---------|--------|---------|--------|-------|--------|----------|
-| 2022-03-17_01 | 20.04  | 20.10.13 | 1.23.5   | 4.10.3 | 3.8.1  | 1.1.7     | 1.22.76  | 2.34.1 | 377.0.0    | 5.5.0   | 3.0.3  | 8.9p1   | 1.23.0 | 1.9.4 | 1.8.1  |  0.18.7  |
+| RELEASE       | UBUNTU | DOCKER   | KUBECTL  | OC CLI | HELM   | TERRAFORM | AWS CLI  | AZ CLI | GCLOUD SDK | ANSIBLE | JINJA2 | OPENSSH | CRICTL | VAULT  | VELERO | SENTINEL |
+|---------------|--------|----------|----------|--------|--------|-----------|----------|--------|------------|---------|--------|---------|--------|--------|--------|----------|
+| 2022-04-26_01 | 20.04  | 20.10.14 | 1.23.6   | 4.10.9 | 3.8.2  | 1.1.9     | 1.23.0   | 2.36.0 | 382.0.0    | 5.6.0   | 3.1.1  | 9.0p1   | 1.23.0 | 1.10.1 | 1.8.1  |  0.18.9  |
+| 2022-03-17_01 | 20.04  | 20.10.13 | 1.23.5   | 4.10.3 | 3.8.1  | 1.1.7     | 1.22.76  | 2.34.1 | 377.0.0    | 5.5.0   | 3.0.3  | 8.9p1   | 1.23.0 | 1.9.4  | 1.8.1  |  0.18.7  |
 
 ## [ version history before 2022-03-17](https://github.com/ksandermann/cloud-toolbox/blob/master/docs/version_history.md)

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2021-12-15_01"
+IMAGE_TAG="2022-04-26_01"
 UPSTREAM_TAG="latest"
 UPSTREAM_TAG2="project"
 


### PR DESCRIPTION
# changelog

* bumped docker to 20.10.14
* bumped kubectl to 1.23.6
* bumped openshift-cli to 4.10.9
* bumped helm to 3.8.2
* bumped aws-cli to 1.23.0
* bumped azure-cli to 2.36.0 
* bumped ansible to 5.6.0
* bumped jinja2 to 3.1.1
* bumped openssh to 9.0p1
* bumped vault to 1.10.1
* bumped sentinel to 0.18.9
