### PR TITLE
2022-08-25 - arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN mkdir -p /root/download/docker/bin && \
     set -eux; \
     arch="$(uname -m)"; \
     if ! wget -O docker.tgz "https://download.docker.com/linux/static/stable/${arch}/docker-${DOCKER_VERSION}.tgz"; then \
-        echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from 'stable' for '${TARGETARCH}'"; \
+        echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from 'stable' for '${arch}'"; \
         exit 1; \
     fi; \
     tar --extract \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,22 @@ ARG UBUNTU_VERSION=20.04
 #https://docs.docker.com/engine/release-notes/
 ARG DOCKER_VERSION="20.10.17"
 #https://github.com/kubernetes/kubernetes/releases
-ARG KUBECTL_VERSION="1.24.3"
+ARG KUBECTL_VERSION="1.25.0"
 #https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
-ARG OC_CLI_VERSION="4.10.23"
+ARG OC_CLI_VERSION="4.11.0"
 #https://github.com/helm/helm/releases
-ARG HELM_VERSION="3.9.2"
+ARG HELM_VERSION="3.9.4"
 ARG TERRAFORM14_VERSION="0.14.11"
 #https://github.com/hashicorp/terraform/releases
-ARG TERRAFORM_VERSION="1.2.6"
+ARG TERRAFORM_VERSION="1.2.8"
 #https://pypi.org/project/awscli/
-ARG AWS_CLI_VERSION="1.25.41"
+ARG AWS_CLI_VERSION="1.25.60"
 #apt-get update && apt-cache madison azure-cli | head -n 1
-ARG AZ_CLI_VERSION="2.38.0-1~focal"
+ARG AZ_CLI_VERSION="2.39.0"
 #apt-get update && apt-cache madison google-cloud-sdk | head -n 1
-ARG GCLOUD_VERSION="395.0.0-0"
+ARG GCLOUD_VERSION="399.0.0-0"
 #https://pypi.org/project/ansible/
-ARG ANSIBLE_VERSION="6.1.0"
+ARG ANSIBLE_VERSION="6.3.0"
 #https://pypi.org/project/Jinja2/
 ARG JINJA_VERSION="3.1.2"
 #https://mirror.exonetric.net/pub/OpenBSD/OpenSSH/portable/
@@ -28,22 +28,23 @@ ARG OPENSSH_VERSION="9.0p1"
 #https://github.com/kubernetes-sigs/cri-tools/releases
 ARG CRICTL_VERSION="1.24.2"
 #https://github.com/hashicorp/vault/releases
-ARG VAULT_VERSION="1.11.1"
+ARG VAULT_VERSION="1.11.2"
 #https://github.com/vmware-tanzu/velero/releases
-ARG VELERO_VERSION="1.9.0"
+ARG VELERO_VERSION="1.9.1"
 #https://docs.hashicorp.com/sentinel/changelog
 ARG SENTINEL_VERSION="0.18.11"
 #https://github.com/stern/stern/releases
 ARG STERN_VERSION="1.21.0"
 #apt-get update && apt-cache madison zsh | head -n 1
 ARG ZSH_VERSION="5.8-3ubuntu1.1"
-ARG MULTISTAGE_BUILDER_VERSION="2022-03-17"
+ARG MULTISTAGE_BUILDER_VERSION="2022-08-25"
 
 ######################################################### BUILDER ######################################################
 FROM ksandermann/multistage-builder:$MULTISTAGE_BUILDER_VERSION as builder
 MAINTAINER Kevin Sandermann <kevin.sandermann@gmail.com>
 LABEL maintainer="kevin.sandermann@gmail.com"
 
+ARG TARGETARCH
 ARG OC_CLI_VERSION
 ARG HELM_VERSION
 ARG TERRAFORM14_VERSION
@@ -58,28 +59,30 @@ ARG STERN_VERSION
 
 #download oc-cli
 WORKDIR /root/download
+
 RUN mkdir -p oc_cli && \
-    curl -SsL --retry 5 -o oc_cli.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux-$OC_CLI_VERSION.tar.gz && \
+    curl -SsL --retry 5 -o oc_cli.tar.gz https://mirror.openshift.com/pub/openshift-v4/$TARGETARCH/clients/ocp/stable/openshift-client-linux-$OC_CLI_VERSION.tar.gz && \
     tar xvf oc_cli.tar.gz -C oc_cli
 
 #download helm3-cli
-RUN mkdir helm && curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz" | tar xz -C ./helm
+RUN mkdir helm && curl -SsL --retry 5 "https://get.helm.sh/helm-v$HELM_VERSION-linux-$TARGETARCH.tar.gz" | tar xz -C ./helm
 
 #download terraform 0.14
-RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM14_VERSION}/terraform\_${TERRAFORM14_VERSION}\_linux_amd64.zip && \
-    unzip ./terraform\_${TERRAFORM14_VERSION}\_linux_amd64.zip -d terraform14_cli
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM14_VERSION}/terraform\_${TERRAFORM14_VERSION}\_linux_${TARGETARCH}.zip && \
+    unzip ./terraform\_${TERRAFORM14_VERSION}\_linux_${TARGETARCH}.zip -d terraform14_cli
 
 #download terraform
-RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform\_${TERRAFORM_VERSION}\_linux_amd64.zip && \
-    unzip ./terraform\_${TERRAFORM_VERSION}\_linux_amd64.zip -d terraform_cli
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform\_${TERRAFORM_VERSION}\_linux_${TARGETARCH}.zip && \
+    unzip ./terraform\_${TERRAFORM_VERSION}\_linux_${TARGETARCH}.zip -d terraform_cli
 
 #download docker
 #credits to https://github.com/docker-library/docker/blob/463595652d2367887b1ffe95ec30caa00179be72/18.09/Dockerfile
+#need to stick to uname since docker download link uses "aarch64" instead of "arm64"
 RUN mkdir -p /root/download/docker/bin && \
     set -eux; \
     arch="$(uname -m)"; \
     if ! wget -O docker.tgz "https://download.docker.com/linux/static/stable/${arch}/docker-${DOCKER_VERSION}.tgz"; then \
-        echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from 'stable' for '${arch}'"; \
+        echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from 'stable' for '${TARGETARCH}'"; \
         exit 1; \
     fi; \
     tar --extract \
@@ -88,39 +91,38 @@ RUN mkdir -p /root/download/docker/bin && \
         --directory /root/download/docker/bin
 
 #download kubectl
-RUN wget https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl -O /root/download/kubectl
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/${TARGETARCH}/kubectl -O /root/download/kubectl
 
 #download crictl
 RUN mkdir -p /root/download/crictl && \
-    wget "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$CRICTL_VERSION/crictl-v$CRICTL_VERSION-linux-amd64.tar.gz" -O /root/download/crictl.tar.gz && \
+    wget "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$CRICTL_VERSION/crictl-v$CRICTL_VERSION-linux-${TARGETARCH}.tar.gz" -O /root/download/crictl.tar.gz && \
     tar zxvf /root/download/crictl.tar.gz -C /root/download/crictl  && \
     chmod +x /root/download/crictl/crictl
 
-
 #download yq
-RUN curl -Lo yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+RUN curl -Lo yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}
 
 #download vault
-RUN wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
-    unzip ./vault_${VAULT_VERSION}_linux_amd64.zip
+RUN wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_${TARGETARCH}.zip && \
+    unzip ./vault_${VAULT_VERSION}_linux_${TARGETARCH}.zip
 
 #download tcpping
 #todo: switch to https://github.com/deajan/tcpping/blob/master/tcpping when ubuntu is supported
 RUN wget https://raw.githubusercontent.com/deajan/tcpping/original-1.8/tcpping -O /root/download/tcpping
 
 #download velero CLI
-RUN wget https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz && \
-   tar -xvf velero-v${VELERO_VERSION}-linux-amd64.tar.gz && \
+RUN wget https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz && \
+   tar -xvf velero-v${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz && \
    mkdir -p /root/download/velero_binary && \
-   mv velero-v${VELERO_VERSION}-linux-amd64/velero /root/download/velero_binary/velero
+   mv velero-v${VELERO_VERSION}-linux-${TARGETARCH}/velero /root/download/velero_binary/velero
 
 #download terraform sentinel
-RUN curl https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_linux_amd64.zip --output ./sentinel.zip && \
+RUN curl https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_linux_${TARGETARCH}.zip --output ./sentinel.zip && \
   unzip ./sentinel.zip -d ./sentinel_binary
 
 #download stern
 RUN mkdir -p /root/download/stern && \
-    wget https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_amd64.tar.gz -O /root/download/stern_arch.tar.gz && \
+    wget https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_${TARGETARCH}.tar.gz -O /root/download/stern_arch.tar.gz && \
     tar zxvf /root/download/stern_arch.tar.gz -C /root/download/stern && \
     mkdir -p /root/download/stern_binary && \
     mv /root/download/stern/stern /root/download/stern_binary/stern
@@ -131,6 +133,7 @@ FROM ubuntu:$UBUNTU_VERSION
 MAINTAINER Kevin Sandermann <kevin.sandermann@gmail.com>
 LABEL maintainer="kevin.sandermann@gmail.com"
 
+ARG TARGETARCH
 # tooling versions
 ARG OPENSSH_VERSION
 ARG KUBECTL_VERSION
@@ -225,12 +228,13 @@ RUN wget "https://mirror.exonetric.net/pub/OpenBSD/OpenSSH/portable/openssh-${OP
     rm -rf ../openssh-${OPENSSH_VERSION}.tar.gz ../openssh-${OPENSSH_VERSION} && \
     ssh -V
 
-#install ansible + common requirements
-RUN pip3 install pip --upgrade
-RUN pip3 install cryptography
-RUN pip3 install \
+#install ansible + azure-cli common requirements
+#RUN pip3 install pip --upgrade
+RUN apt remove azure-cli -y || true && \
+    pip3 install \
     ansible==${ANSIBLE_VERSION} \
     ansible-lint \
+    cryptography \
     hvac \
     jinja2==${JINJA_VERSION} \
     jmespath \
@@ -241,37 +245,59 @@ RUN pip3 install \
     pip \
     pyOpenSSL \
     pyvmomi \
-    setuptools
+    setuptools && \
+    pip3 install \
+    azure-cli==${AZ_CLI_VERSION}
+
+#test azure-cli
+RUN az --version && \
+    az extension add --name azure-devops && \
+    az extension add --name ssh && \
+    az extension add --nameserial-console && \
+    az extension add --namesentinel && \
+    az extension add --nameresource-mover && \
+    az extension add --nameresource-graph && \
+    az extension add --namequota && \
+    az extension add --nameportal && \
+    az extension add --namek8sconfiguration && \
+    az extension add --namek8s-extension && \
+    az extension add --namek8s-configuration && \
+    az extension add --name azure-firewall
 
 #install AWS CLI
-RUN pip3 install awscli==$AWS_CLI_VERSION --upgrade && \
+RUN pip3 install awscli==$AWS_CLI_VERSION && \
     aws --version
 
 
-#install azure cli
-#Ubuntu 20.04 (Focal Fossa), includes an azure-cli package with version 2.0.81 provided by the focal/universe repository. This package is outdated and and not recommended. If this package is installed, remove the package before continuing by running the command sudo apt remove azure-cli -y && sudo apt autoremove -y.
-RUN apt remove azure-cli -y && apt autoremove -y && \
-    curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
-    gpg --dearmor | \
-    tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
-    AZ_REPO=$(lsb_release -cs) && \
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
-    tee /etc/apt/sources.list.d/azure-cli.list && \
-    apt-get update && \
-    apt-get install -y azure-cli=$AZ_CLI_VERSION && \
-    az --version && \
-    az extension add --name azure-devops && \
-    az extension add --name ssh
+##install azure cli
+##Ubuntu 20.04 (Focal Fossa), includes an azure-cli package with version 2.0.81 provided by the focal/universe repository. This package is outdated and and not recommended. If this package is installed, remove the package before continuing by running the command sudo apt remove azure-cli -y && sudo apt autoremove -y.
+#RUN apt remove azure-cli -y || true && apt autoremove -y && \
+#    curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
+#    gpg --dearmor | \
+#    tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
+#    AZ_REPO=$(lsb_release -cs) && \
+#    AZ_ARCH=$(dpkg --print-architecture) && \
+#    echo "deb [arch=$AZ_ARCH] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
+#    tee /etc/apt/sources.list.d/azure-cli.list && \
+#    apt-get update && \
+#    apt-get install -y azure-cli=$AZ_CLI_VERSION:$AZ_ARCH && \
+#    az --version && \
+#    az extension add --name azure-devops && \
+#    az extension add --name ssh
+#
+##$ curl -L https://aka.ms/InstallAzureCli >> installAzureCli.sh
+##$ curl https://azurecliprod.blob.core.windows.net/install.py >> installAzureCliPython.py
+##$ sudo chmod +x installAzureCliPython.py
+##$ python3 installAzureCliPython.py
 
 #install gcloud
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
     apt-get update && \
-    apt-get install -y \
-    google-cloud-sdk=${GCLOUD_VERSION}
+    apt-get install -y google-cloud-sdk=${GCLOUD_VERSION}
 
 #install binaries
-COPY --from=builder "/root/download/helm/linux-amd64/helm" "/usr/local/bin/helm"
+COPY --from=builder "/root/download/helm/linux-${TARGETARCH}/helm" "/usr/local/bin/helm"
 COPY --from=builder "/root/download/oc_cli/oc" "/usr/local/bin/oc"
 COPY --from=builder "/root/download/terraform14_cli/terraform" "/usr/local/bin/terraform14"
 COPY --from=builder "/root/download/terraform_cli/terraform" "/usr/local/bin/terraform"

--- a/Dockerfile
+++ b/Dockerfile
@@ -215,9 +215,6 @@ ENV TERM xterm
 ENV ZSH_THEME agnoster
 RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true
 
-#keep standard shell for automation usecases
-#RUN chsh -s /bin/zsh
-
 #install OpenSSH
 RUN wget "https://mirror.exonetric.net/pub/OpenBSD/OpenSSH/portable/openssh-${OPENSSH_VERSION}.tar.gz" --no-check-certificate && \
     tar xfz openssh-${OPENSSH_VERSION}.tar.gz && \
@@ -229,7 +226,6 @@ RUN wget "https://mirror.exonetric.net/pub/OpenBSD/OpenSSH/portable/openssh-${OP
     ssh -V
 
 #install ansible + azure-cli common requirements
-#RUN pip3 install pip --upgrade
 RUN apt remove azure-cli -y || true && \
     pip3 install \
     ansible==${ANSIBLE_VERSION} \
@@ -253,42 +249,20 @@ RUN apt remove azure-cli -y || true && \
 RUN az --version && \
     az extension add --name azure-devops && \
     az extension add --name ssh && \
-    az extension add --nameserial-console && \
-    az extension add --namesentinel && \
-    az extension add --nameresource-mover && \
-    az extension add --nameresource-graph && \
-    az extension add --namequota && \
-    az extension add --nameportal && \
-    az extension add --namek8sconfiguration && \
-    az extension add --namek8s-extension && \
-    az extension add --namek8s-configuration && \
+    az extension add --name serial-console && \
+    az extension add --name sentinel && \
+    az extension add --name resource-mover && \
+    az extension add --name resource-graph && \
+    az extension add --name quota && \
+    az extension add --name portal && \
+    az extension add --name k8sconfiguration && \
+    az extension add --name k8s-extension && \
+    az extension add --name k8s-configuration && \
     az extension add --name azure-firewall
 
 #install AWS CLI
 RUN pip3 install awscli==$AWS_CLI_VERSION && \
     aws --version
-
-
-##install azure cli
-##Ubuntu 20.04 (Focal Fossa), includes an azure-cli package with version 2.0.81 provided by the focal/universe repository. This package is outdated and and not recommended. If this package is installed, remove the package before continuing by running the command sudo apt remove azure-cli -y && sudo apt autoremove -y.
-#RUN apt remove azure-cli -y || true && apt autoremove -y && \
-#    curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
-#    gpg --dearmor | \
-#    tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
-#    AZ_REPO=$(lsb_release -cs) && \
-#    AZ_ARCH=$(dpkg --print-architecture) && \
-#    echo "deb [arch=$AZ_ARCH] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
-#    tee /etc/apt/sources.list.d/azure-cli.list && \
-#    apt-get update && \
-#    apt-get install -y azure-cli=$AZ_CLI_VERSION:$AZ_ARCH && \
-#    az --version && \
-#    az extension add --name azure-devops && \
-#    az extension add --name ssh
-#
-##$ curl -L https://aka.ms/InstallAzureCli >> installAzureCli.sh
-##$ curl https://azurecliprod.blob.core.windows.net/install.py >> installAzureCliPython.py
-##$ sudo chmod +x installAzureCliPython.py
-##$ python3 installAzureCliPython.py
 
 #install gcloud
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG TERRAFORM14_VERSION="0.14.11"
 ARG TERRAFORM_VERSION="1.2.8"
 #https://pypi.org/project/awscli/
 ARG AWS_CLI_VERSION="1.25.60"
-#apt-get update && apt-cache madison azure-cli | head -n 1
+#https://pypi.org/project/azure-cli/
 ARG AZ_CLI_VERSION="2.39.0"
 #apt-get update && apt-cache madison google-cloud-sdk | head -n 1
 ARG GCLOUD_VERSION="399.0.0-0"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ All CAs placed inside ```~/ca-certificates``` on the host system will be mounted
 While a lot of projects and workspaces have already been upgraded to terraform >= 0.15, terraform 0.14 remains necessary to ugprade old workspaces.
 0.14 can be used via binary `terraform14`, while 1 is available via binary `terraform`.
 
+# multi-platform support
+Starting with release *2022-08-25_01*, arm64/aarch64 and amd64 are supported and have been tested on linux/amd64 and Macbook M1.
+
 # versioning
 Release tags will be build following pattern YYYY-MM-dd-version.
 Version 01 of a date will always contain the latest stable/official versions of tooling available.
@@ -29,13 +32,14 @@ Other versions of a date can contain version combinations of the toolchain and w
 below.
 
 ## version history
-latest -> 2022-07-30_01
+latest -> 2022-08-25_01
 
-project -> 2022-07-30_01
+project -> 2022-08-25_01
 
 
 | RELEASE       | UBUNTU | DOCKER   | KUBECTL | OC CLI  | HELM  | TERRAFORM | AWS CLI | AZ CLI | GCLOUD SDK | ANSIBLE | JINJA2 | OPENSSH | CRICTL | VAULT  | VELERO | SENTINEL |
 |---------------|--------|----------|---------|---------|-------|-----------|---------|--------|------------|---------|--------|---------|--------|--------|--------|----------|
+| 2022-08-25_01 | 20.04  | 20.10.17 | 1.25.0  | 4.11.0  | 3.9.4 | 1.2.8     | 1.25.60 | 2.39.0 | 399.0.0    | 6.3.0   | 3.1.2  | 9.0p1   | 1.24.2 | 1.11.2 | 1.9.1  |  0.18.11 |
 | 2022-07-30_01 | 20.04  | 20.10.17 | 1.24.3  | 4.10.23 | 3.9.2 | 1.2.6     | 1.25.41 | 2.38.0 | 395.0.0    | 6.1.0   | 3.1.2  | 9.0p1   | 1.24.2 | 1.11.1 | 1.9.0  |  0.18.11 |
 | 2022-07-13_01 | 20.04  | 20.10.17 | 1.24.2  | 4.10.20 | 3.9.0 | 1.2.5     | 1.25.28 | 2.38.0 | 393.0.0    | 6.1.0   | 3.1.2  | 9.0p1   | 1.24.2 | 1.11.0 | 1.9.0  |  0.18.11 |
 | 2022-06-16_01 | 20.04  | 20.10.17 | 1.24.1  | 4.10.17 | 3.9.0 | 1.2.3     | 1.25.9  | 2.37.0 | 390.0.0    | 5.9.0   | 3.1.2  | 9.0p1   | 1.24.2 | 1.10.4 | 1.8.1  |  0.18.11 |

--- a/build.sh
+++ b/build.sh
@@ -2,31 +2,19 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2022-08-25_multiarch"
+IMAGE_TAG="2022-08-25"
 UPSTREAM_TAG="latest"
 UPSTREAM_TAG2="project"
 
-#https://blog.jaimyn.dev/how-to-build-multi-architecture-docker-images-on-an-m1-mac/
+docker login
 
+#https://blog.jaimyn.dev/how-to-build-multi-architecture-docker-images-on-an-m1-mac/
 docker buildx build \
+    --no-cache \
     --pull \
     --platform linux/amd64,linux/arm64 \
     --push \
     -t ksandermann/cloud-toolbox:$IMAGE_TAG \
+    -t ksandermann/cloud-toolbox:$UPSTREAM_TAG \
+    -t ksandermann/cloud-toolbox:$UPSTREAM_TAG2 \
     .
-
-
-    #--no-cache \
-
-
-#docker login
-#docker push ksandermann/cloud-toolbox:$IMAGE_TAG
-#
-#docker tag ksandermann/cloud-toolbox:$IMAGE_TAG ksandermann/cloud-toolbox:$UPSTREAM_TAG
-#docker push ksandermann/cloud-toolbox:$UPSTREAM_TAG
-#
-#docker tag ksandermann/cloud-toolbox:$IMAGE_TAG ksandermann/cloud-toolbox:$UPSTREAM_TAG2
-#docker push ksandermann/cloud-toolbox:$UPSTREAM_TAG2
-#
-#
-#

--- a/build.sh
+++ b/build.sh
@@ -2,21 +2,31 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2022-07-30_01"
+IMAGE_TAG="2022-08-25_multiarch"
 UPSTREAM_TAG="latest"
 UPSTREAM_TAG2="project"
 
-docker build \
+#https://blog.jaimyn.dev/how-to-build-multi-architecture-docker-images-on-an-m1-mac/
+
+docker buildx build \
     --pull \
-    --no-cache \
+    --platform linux/amd64,linux/arm64 \
+    --push \
     -t ksandermann/cloud-toolbox:$IMAGE_TAG \
     .
 
-docker login
-docker push ksandermann/cloud-toolbox:$IMAGE_TAG
 
-docker tag ksandermann/cloud-toolbox:$IMAGE_TAG ksandermann/cloud-toolbox:$UPSTREAM_TAG
-docker push ksandermann/cloud-toolbox:$UPSTREAM_TAG
+    #--no-cache \
 
-docker tag ksandermann/cloud-toolbox:$IMAGE_TAG ksandermann/cloud-toolbox:$UPSTREAM_TAG2
-docker push ksandermann/cloud-toolbox:$UPSTREAM_TAG2
+
+#docker login
+#docker push ksandermann/cloud-toolbox:$IMAGE_TAG
+#
+#docker tag ksandermann/cloud-toolbox:$IMAGE_TAG ksandermann/cloud-toolbox:$UPSTREAM_TAG
+#docker push ksandermann/cloud-toolbox:$UPSTREAM_TAG
+#
+#docker tag ksandermann/cloud-toolbox:$IMAGE_TAG ksandermann/cloud-toolbox:$UPSTREAM_TAG2
+#docker push ksandermann/cloud-toolbox:$UPSTREAM_TAG2
+#
+#
+#


### PR DESCRIPTION
# changelog

* added multi-platform support for arm64 and amd64
* bumped multistage-builder builder image to multi-arch tag 2022-08-25
* bumped kubectl to 1.25.0
* bumped oc-cli to 4.11.0
* bumped helm to 3.9.4
* bumped terraform to 1.2.8
* bumped aws-cli to 1.25.60
* bumped azure-cli to 2.39.0
* bumped gcloud-sdk to 399.0.0
* bumped ansible to 6.3.0
* bumped vault to 1.11.2
* bumped velero to 1.9.1
