### PR TITLE
release 2022-11-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ Version *base* of a date will always contain the latest stable/official versions
 
 Version *complete* will always contain the latest stable/official versions of tooling available of version *complete*.
 
-For a list of tooling available in version *complete*, but not in *base*, please refer [here](https://github.com/ksandermann/cloud-toolbox/blob/master/docs/args_optional.args)
+For a list of tooling available in version *complete*, but not in *base*, please refer [here](https://github.com/ksandermann/cloud-toolbox/blob/master/args_optional.args)
 
 ## version history
 latest -> 2022-11-05_base
 project -> 2022-11-05_base
 complete -> 2022-11-05_complete
 
-| RELEASE             | UBUNTU | DOCKER   | KUBECTL | HELM   | TERRAFORM | AZ CLI | OPENSSH | CRICTL | VELERO | SENTINEL | STERN  | KUBELOGIN | OC CLI | AWS CLI | GCLOUD CLI | ANSIBLE | JINJA2  | VAULT  |
-|---------------------|--------|----------|---------|--------|-----------|--------|---------|--------|--------|----------|--------|-----------|--------|---------|------------|---------|---------|--------|
-| 2022-11-05_complete | 20.04  | 20.10.20 | 1.25.3  | 3.10.1 | 1.3.4     | 2.42.0 | 9.1p1   | 1.25.0 | 1.9.2  | 0.18.11  | 1.22.0 | 0.0.20    | 4.11.9 | 1.27.3  | 408.0.1    | 6.5.0   | 3.1.2   | 1.12.1 |
-| 2022-10-11_complete | 20.04  | 20.10.18 | 1.25.2  | 3.10.0 | 1.3.2     | 2.40.0 | 9.1p1   | 1.25.0 | 1.9.2  | 0.18.11  | 1.22.0 | 0.0.20    | 4.11.7 | 1.25.90 | 405.0.0    | 6.4.0   | 3.1.2   | 1.11.4 |
+| RELEASE             | UBUNTU | DOCKER   | KUBECTL | HELM   | TERRAFORM | AZ CLI | OPENSSH | CRICTL | VELERO | SENTINEL | STERN  | KUBELOGIN | OC CLI  | AWS CLI | GCLOUD CLI | ANSIBLE | JINJA2  | VAULT  |
+|---------------------|--------|----------|---------|--------|-----------|--------|---------|--------|--------|----------|--------|-----------|---------|---------|------------|---------|---------|--------|
+| 2022-11-13_complete | 20.04  | 20.10.21 | 1.25.4  | 3.10.2 | 1.3.4     | 2.42.0 | 9.1p1   | 1.25.0 | 1.9.3  | 0.18.13  | 1.22.0 | 0.0.20    | 4.11.12 | 1.27.8  | 409.0.0    | 6.6.0   | 3.1.2   | 1.12.1 |
+| 2022-11-05_complete | 22.04  | 20.10.20 | 1.25.3  | 3.10.1 | 1.3.4     | 2.42.0 | 9.1p1   | 1.25.0 | 1.9.2  | 0.18.11  | 1.22.0 | 0.0.20    | 4.11.9  | 1.27.3  | 408.0.1    | 6.5.0   | 3.1.2   | 1.12.1 |
+| 2022-10-11_complete | 20.04  | 20.10.18 | 1.25.2  | 3.10.0 | 1.3.2     | 2.40.0 | 9.1p1   | 1.25.0 | 1.9.2  | 0.18.11  | 1.22.0 | 0.0.20    | 4.11.7  | 1.25.90 | 405.0.0    | 6.4.0   | 3.1.2   | 1.11.4 |
 
-## version history
 ## [version history before 2022-10-10](https://github.com/ksandermann/cloud-toolbox/blob/master/docs/version_history.md)

--- a/args_base.args
+++ b/args_base.args
@@ -1,10 +1,10 @@
-UBUNTU_VERSION=22.04
+UBUNTU_VERSION=20.04
 #https://docs.docker.com/engine/release-notes/
-DOCKER_VERSION=20.10.20
+DOCKER_VERSION=20.10.21
 #https://github.com/kubernetes/kubernetes/releases
-KUBECTL_VERSION=1.25.3
+KUBECTL_VERSION=1.25.4
 #https://github.com/helm/helm/releases
-HELM_VERSION=3.10.1
+HELM_VERSION=3.10.2
 #https://github.com/hashicorp/terraform/releases
 TERRAFORM_VERSION=1.3.4
 #https://pypi.org/project/azure-cli/
@@ -14,13 +14,13 @@ OPENSSH_VERSION=9.1p1
 #https://github.com/kubernetes-sigs/cri-tools/releases
 CRICTL_VERSION=1.25.0
 #https://github.com/vmware-tanzu/velero/releases
-VELERO_VERSION=1.9.2
+VELERO_VERSION=1.9.3
 #https://docs.hashicorp.com/sentinel/changelog
-SENTINEL_VERSION=0.18.11
+SENTINEL_VERSION=0.18.13
 #https://github.com/stern/stern/releases
 STERN_VERSION=1.22.0
 #https://github.com/Azure/kubelogin/releases
 KUBELOGIN_VERSION=0.0.20
 #apt-get update && apt-cache madison zsh | head -n 1
-ZSH_VERSION=5.8.1-1
+ZSH_VERSION=5.8-3ubuntu1.1
 MULTISTAGE_BUILDER_VERSION=2022-08-25

--- a/args_optional.args
+++ b/args_optional.args
@@ -1,12 +1,11 @@
 #https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
-OC_CLI_VERSION=4.11.9
+OC_CLI_VERSION=4.11.12
 #https://pypi.org/project/awscli/
-AWS_CLI_VERSION=1.27.3
-#https://packages.cloud.google.com/apt/dists
-#apt-get update && apt-cache madison google-cloud-cli | head -n 1
-GCLOUD_VERSION=408.0.1-0
+AWS_CLI_VERSION=1.27.8
+#https://console.cloud.google.com/storage/browser/cloud-sdk-release;tab=objects
+GCLOUD_VERSION=409.0.0-0
 #https://pypi.org/project/ansible/
-ANSIBLE_VERSION=6.5.0
+ANSIBLE_VERSION=6.6.0
 #https://pypi.org/project/Jinja2/
 JINJA_VERSION=3.1.2
 #https://github.com/hashicorp/vault/releases

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-IMAGE_TAG="2022-11-05"
+IMAGE_TAG="2022-11-13"
 TAG_PREFIX_COMPLETE="complete"
 TAG_PREFIX_BASE="latest"
 TAG_PREFIX_BASE2="project"


### PR DESCRIPTION
# changelog

* downported Ubuntu to 20.04 due to issues with git 
* bumped docker to 20.10.21
* bumped kubectl to 1.25.4
* bumped helm to 3.10.2
* bumped velero to 1.9.3
* bumped sentinel to 0.18.13
* bumped zsh to 5.8.3 again since this is compatible with Ubuntu 20.04
* bumped oc-cli tp 4.11.12
* bumped aws-cli to 1.27.8
* bumped gcloud-cli to 409.0.0
* bumped ansible to 6.6.0