### PR TITLE
Upgrade base image to Ubuntu 24.04 (noble)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,12 @@ SHELL ["/bin/bash", "-c"]
 #env
 ENV DEBIAN_FRONTEND noninteractive
 
+#Ubuntu 24.04 marks its system Python as externally managed (PEP 668), so the
+#pip3 installs below are refused outright. This is a single-purpose toolbox
+#image, not a general-purpose OS, so installing into the system interpreter is
+#exactly what we want.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
 USER root
 WORKDIR /root
 
@@ -218,7 +224,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsb-release \
     nano \
     net-tools \
-    netcat \
+    netcat-openbsd \
     nmap \
     openssl
 
@@ -260,11 +266,11 @@ RUN apt-get update && apt-get install -y \
     make \
     openssl
 
-# upgrade pip 
-RUN pip3 install --upgrade pip 
+# upgrade pip
+RUN pip3 install --upgrade --ignore-installed pip
 
 #install common requirements
-RUN pip3 install \
+RUN pip3 install --ignore-installed \
     cryptography \
     hvac \
     jmespath \

--- a/args_base.args
+++ b/args_base.args
@@ -1,5 +1,5 @@
 MULTISTAGE_BUILDER_VERSION=2022-12-21
-UBUNTU_VERSION=22.04
+UBUNTU_VERSION=24.04
 #https://github.com/moby/moby/releases
 DOCKER_VERSION=29.7.2
 #https://github.com/kubernetes/kubernetes/releases
@@ -11,7 +11,7 @@ TERRAFORM_VERSION=1.15.9
 #https://pypi.org/project/azure-cli/
 AZ_CLI_VERSION=2.89.1
 #apt-cache madison openssh-client | head -n1
-OPENSSH_VERSION=1:8.9p1-3ubuntu0.16
+OPENSSH_VERSION=1:9.6p1-3ubuntu13.19
 #https://github.com/kubernetes-sigs/cri-tools/releases
 CRICTL_VERSION=1.36.0
 #https://github.com/vmware-tanzu/velero/releases
@@ -23,5 +23,5 @@ STERN_VERSION=1.34.0
 #https://github.com/Azure/kubelogin/releases
 KUBELOGIN_VERSION=0.1.9
 #apt-get update && apt-cache madison zsh | head -n 1
-ZSH_VERSION=5.8.1-1
+ZSH_VERSION=5.9-6ubuntu2
 #endline

--- a/args_optional.args
+++ b/args_optional.args
@@ -1,5 +1,5 @@
 #https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
-OC_CLI_VERSION=4.22.9
+OC_CLI_VERSION=4.22.11
 #https://pypi.org/project/awscli/
 AWS_CLI_VERSION=1.46.0
 #apt-cache madison google-cloud-cli | head -n1
@@ -10,3 +10,4 @@ ANSIBLE_VERSION=9.9.0
 JINJA_VERSION=3.1.6
 #https://github.com/hashicorp/vault/releases
 VAULT_VERSION=2.0.4
+#endline


### PR DESCRIPTION
Three changes are genuine 24.04 incompatibilities:

- PEP 668: noble ships python3.12 marked externally-managed, so every system-wide pip3 install is refused. PIP_BREAK_SYSTEM_PACKAGES=1 covers all five call sites at once; this is a single-purpose toolbox image, so installing into the system interpreter is the intent.
- Debian's pip carries no RECORD file, so pip cannot uninstall it in order to replace it ("Cannot uninstall pip 24.0, RECORD file not found"). --ignore-installed installs alongside instead, matching the idiom already used for azure-cli.
- netcat is a virtual package in noble with no default provider; jammy's transitional package pulled in netcat-openbsd, so depend on it directly.

The openssh and zsh pins are re-pinned to their noble equivalents, since the jammy versions do not exist there.

Two further fixes are unrelated to the Ubuntu bump and break master today:

- OC_CLI_VERSION 4.22.9 has rotated off mirror.openshift.com, which only keeps the current release under clients/ocp/stable (404 on both arches).
- args_optional.args had no trailing newline, so the read loop in build.sh silently dropped VAULT_VERSION and vault was never installed — the published complete image has never contained it. Terminated with the same #endline marker args_base.args already uses for this reason.

Verified on linux/arm64: base 13/13 and complete 19/19 pinned tools present and version-matched via verify_tools.sh.